### PR TITLE
Add correct navigation after 5 questions are answered

### DIFF
--- a/src/components/EndPage/EndPage.tsx
+++ b/src/components/EndPage/EndPage.tsx
@@ -1,8 +1,17 @@
+import './EndPage.scss'
+import { useNavigate } from 'react-router-dom'
+
 const EndPage = () => {
+const navigate = useNavigate()
+
+  const backtoMainClick = () => {
+    navigate('/')
+  }
+
   return (
     <div>
       <p>Your Score</p>
-      <button className="return-to-main" />
+      <button onClick={backtoMainClick} className="return-to-main">Back to Start</button>
     </div>
   );
 };

--- a/src/components/GamePage/GamePage.tsx
+++ b/src/components/GamePage/GamePage.tsx
@@ -1,4 +1,6 @@
 import QuestionCard from '../QuestionCard/QuestionCard';
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom'
 
 const GamePage = ({
   questionInfo,
@@ -7,6 +9,26 @@ const GamePage = ({
   setScore,
   setQuestions,
 }: any) => {
+ 
+  const [answeredQuestions, setAnsweredQuestions] = useState<number>(0);
+  const navigate = useNavigate()
+  const increaseScore = () => {
+    setScore((prevScore: number) => {
+      const newScore = prevScore + 1;
+      console.log('New Score:', newScore);
+      return newScore;
+    });
+  }
+
+  const handleScoreUpdate = () => {
+    setAnsweredQuestions((prevCount: number) => prevCount + 1);
+  };
+  
+    if (answeredQuestions === 5) {
+      setTimeout(() => {navigate("/end")}, 3000);
+    }
+
+
   return (
     <main>
       <QuestionCard
@@ -15,6 +37,8 @@ const GamePage = ({
         selectedDifficulty={selectedDifficulty}
         setScore={setScore}
         setQuestions={setQuestions}
+        increaseScore={increaseScore}
+        handleScoreUpdate={handleScoreUpdate}
       />
     </main>
   );

--- a/src/components/QuestionCard/QuestionCard.tsx
+++ b/src/components/QuestionCard/QuestionCard.tsx
@@ -8,6 +8,8 @@ const QuestionCard = ({
   selectedDifficulty,
   setScore,
   setQuestions,
+  increaseScore,
+  handleScoreUpdate,
 }: QuestionCardProps) => {
   const [correctAnswer, setCorrectAnswer] = useState<string>('');
   const [showCorrectAnswer, setShowCorrectAnswer] = useState<boolean>(false);
@@ -28,16 +30,9 @@ const QuestionCard = ({
     setShowButton(true);
 
     if (answer === correctAnswer) {
-      increaseScore(setScore);
+      increaseScore();
     }
-  };
-
-  const increaseScore = (setScore: any) => {
-    setScore((prevScore: number) => {
-      const newScore = prevScore + 1;
-      console.log('New Score:', newScore);
-      return newScore;
-    });
+    handleScoreUpdate();
   };
 
   const handleButtonClick = async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,4 +13,6 @@ export interface QuestionCardProps {
   selectedDifficulty: any;
   setScore: (score: number) => void;
   setQuestions: (questions: Question[]) => void;
+  increaseScore: () => void;
+  handleScoreUpdate: () => void 
 }


### PR DESCRIPTION
What I did: After 5 questions the game navigates to the end page. 

Did this break anything?

- [x]  No
- [ ]  Yes

Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.
- [ ]  Testing 

Checklist:

- [ ]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next?
Getting the score to display on the endpage and starting css 

What we've learned:  📖 
Typescript has been a bit of a challenge as it is very picky about the what types are needed and what syntax is needed for certain types depending on where there placement is. Otherwise we've managed pretty well using lessons, guides and mentors along the way to get to where the game is at now. We meant to give you a better pr for when we added cool stuff but got so ahead of ourselves we spaced! Currently our focus has been all functionality, so be prepared for zero CSS. Please enjoy! We are excited for the feedback. 😃 
