### PR TITLE
Bug fix/use effect for shuffle answers

### DIFF
--- a/src/components/QuestionCard/QuestionCard.tsx
+++ b/src/components/QuestionCard/QuestionCard.tsx
@@ -15,14 +15,23 @@ const QuestionCard = ({
   const [showCorrectAnswer, setShowCorrectAnswer] = useState<boolean>(false);
   const [showButton, setShowButton] = useState<boolean>(false);
   const [questionIndex, setQuestionIndex] = useState(0);
+  const [shuffledAnswers, setShuffledAnswers] = useState<null | string[]>(null);
 
-  const shuffleAnswers = (
-    correctAnswer: string,
-    incorrect_answers: string[],
-  ) => {
-    const answers = [correctAnswer, ...incorrect_answers];
-    return arrayShuffle(answers);
-  };
+  useEffect(() => {
+    console.log(questions[questionIndex].correctAnswer)
+    const correctAnswer = questions[questionIndex].correctAnswer
+    const incorrectAnswers = questions[questionIndex].incorrectAnswers
+    const answers = [correctAnswer, ...incorrectAnswers];
+    setShuffledAnswers(arrayShuffle(answers))
+  }, [questions, questionIndex]) 
+
+  // const shuffleAnswers = (
+  //   correctAnswer: string,
+  //   incorrect_answers: string[],
+  // ) => {
+  //   const answers = [correctAnswer, ...incorrect_answers];
+  //   return arrayShuffle(answers);
+  // };
 
   useEffect(() => {
     if (questionIndex === 5) {
@@ -62,10 +71,7 @@ const QuestionCard = ({
       {questions.length > 0 && questionIndex < questions.length && (
         <div key={questionIndex}>
           <h2>{questions[questionIndex].question}</h2>
-          {shuffleAnswers(
-            questions[questionIndex].correctAnswer,
-            questions[questionIndex].incorrectAnswers,
-          ).map((answer, idx) => (
+          {shuffledAnswers && shuffledAnswers.map((answer, idx) => (
             <button
               className='answer-buttons'
               key={idx}


### PR DESCRIPTION
      What I did:
Fixed the bug that shuffled the answers position after the user selects an answer. Now the answers do not shuffle their position after the user clicks on an answer, they only shuffle each time a new question appears.
Did this break anything?

- [ ]  No
- [x]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.
- [ ]  Testing 

Checklist:

- [ ]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [ ]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next?
Getting the answer to disappear when a new question appears.

